### PR TITLE
Fix code scanning alert no. 23: Full server-side request forgery

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -952,12 +952,25 @@ def ssrf_lab2(request):
 
     elif request.method == "POST":
         url = request.POST["url"]
+        from urllib.parse import urlparse
+
         allowed_urls = [
             "https://example.com/resource",
             "https://another-allowed-domain.com/resource"
         ]
+
+        def is_url_allowed(url, allowed_urls):
+            parsed_url = urlparse(url)
+            for allowed_url in allowed_urls:
+                parsed_allowed_url = urlparse(allowed_url)
+                if (parsed_url.scheme == parsed_allowed_url.scheme and
+                    parsed_url.netloc == parsed_allowed_url.netloc and
+                    parsed_url.path == parsed_allowed_url.path):
+                    return True
+            return False
+
         try:
-            if url in allowed_urls:
+            if is_url_allowed(url, allowed_urls):
                 response = requests.get(url)
                 return render(request, "Lab/ssrf/ssrf_lab2.html", {"response": response.content.decode()})
             else:

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -952,14 +952,16 @@ def ssrf_lab2(request):
 
     elif request.method == "POST":
         url = request.POST["url"]
-        allowed_domains = ["example.com", "another-allowed-domain.com"]
+        allowed_urls = [
+            "https://example.com/resource",
+            "https://another-allowed-domain.com/resource"
+        ]
         try:
-            parsed_url = requests.utils.urlparse(url)
-            if parsed_url.hostname in allowed_domains:
+            if url in allowed_urls:
                 response = requests.get(url)
                 return render(request, "Lab/ssrf/ssrf_lab2.html", {"response": response.content.decode()})
             else:
-                return render(request, "Lab/ssrf/ssrf_lab2.html", {"error": "Domain not allowed"})
+                return render(request, "Lab/ssrf/ssrf_lab2.html", {"error": "URL not allowed"})
         except:
             return render(request, "Lab/ssrf/ssrf_lab2.html", {"error": "Invalid URL"})
 #--------------------------------------- Server-side template injection --------------------------------------#

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -952,9 +952,14 @@ def ssrf_lab2(request):
 
     elif request.method == "POST":
         url = request.POST["url"]
+        allowed_domains = ["example.com", "another-allowed-domain.com"]
         try:
-            response = requests.get(url)
-            return render(request, "Lab/ssrf/ssrf_lab2.html", {"response": response.content.decode()})
+            parsed_url = requests.utils.urlparse(url)
+            if parsed_url.hostname in allowed_domains:
+                response = requests.get(url)
+                return render(request, "Lab/ssrf/ssrf_lab2.html", {"response": response.content.decode()})
+            else:
+                return render(request, "Lab/ssrf/ssrf_lab2.html", {"error": "Domain not allowed"})
         except:
             return render(request, "Lab/ssrf/ssrf_lab2.html", {"error": "Invalid URL"})
 #--------------------------------------- Server-side template injection --------------------------------------#


### PR DESCRIPTION
Fixes [https://github.com/fawazzist/Pygoat/security/code-scanning/23](https://github.com/fawazzist/Pygoat/security/code-scanning/23)

To fix the SSRF vulnerability, we need to validate the user-provided URL to ensure it is safe to use. One effective way is to maintain a whitelist of allowed domains and ensure the user-provided URL matches one of these domains. This approach prevents the attacker from directing the server to arbitrary or malicious URLs.

**Steps to fix:**
1. Define a list of allowed domains.
2. Parse the user-provided URL and extract its domain.
3. Check if the extracted domain is in the list of allowed domains.
4. Only proceed with the request if the domain is allowed; otherwise, return an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
