### PR TITLE
Fix code scanning alert no. 22: XML external entity expansion

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -14,9 +14,7 @@ from dataclasses import dataclass
 from hashlib import md5
 from io import BytesIO
 from random import randint
-from xml.dom.pulldom import START_ELEMENT, parseString
-from xml.sax import make_parser
-from xml.sax.handler import feature_external_ges
+from defusedxml.pulldom import START_ELEMENT, parseString
 
 import jwt
 import requests
@@ -249,9 +247,7 @@ def xxe_see(request):
 @csrf_exempt
 def xxe_parse(request):
 
-    parser = make_parser()
-    parser.setFeature(feature_external_ges, True)
-    doc = parseString(request.body.decode('utf-8'), parser=parser)
+    doc = parseString(request.body.decode('utf-8'))
     for event, node in doc:
         if event == START_ELEMENT and node.tagName == 'text':
             doc.expandNode(node)


### PR DESCRIPTION
Fixes [https://github.com/fawazzist/Pygoat/security/code-scanning/22](https://github.com/fawazzist/Pygoat/security/code-scanning/22)

To fix the problem, we need to disable external entity processing when parsing the XML data. This can be achieved by setting the `feature_external_ges` to `False`. Additionally, we should use a safer XML parsing library like `defusedxml` to further mitigate the risk of XXE attacks.

1. Install the `defusedxml` package.
2. Replace the current XML parsing logic with `defusedxml` to ensure external entities are not processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
